### PR TITLE
Take out port feature list when calling remove

### DIFF
--- a/Remove-Requirements.ps1
+++ b/Remove-Requirements.ps1
@@ -37,13 +37,15 @@ if (!$libraries) {
 $json = Get-Content -Raw -Path $libraries | ConvertFrom-Json
 
 $arguments = @('remove')
-$arguments += $json
+foreach ($value in $json) {
+  $arguments += ($value -split '\[')[0];
+}
 $arguments += '--triplet'
 $arguments += $triplet
 
 Write-Host ('vcpkg {0}' -f ($arguments -join ' '))
 
 Start-Process -Wait -NoNewWindow `
-   -FilePath (Join-Path $PSScriptRoot 'vcpkg.exe') `
-   -WorkingDirectory $PSScriptRoot `
-   -ArgumentList $arguments
+  -FilePath (Join-Path $PSScriptRoot 'vcpkg.exe') `
+  -WorkingDirectory $PSScriptRoot `
+  -ArgumentList $arguments


### PR DESCRIPTION
The `vcpkg remove` command will fail when the feature list is present. Split based on the bracket so only the port name is present when calling `vcpkg remove` in the `Remove-Requirements.ps1` script.

Also run formatter.