### PR TITLE
Add CMAKE_CROSSCOMPILING_EMULATOR to ICU tool invocations

### DIFF
--- a/ports/icu/patches/0003-Append-CMAKE_EXECUTABLE_SUFFIX-to-tool-paths.patch
+++ b/ports/icu/patches/0003-Append-CMAKE_EXECUTABLE_SUFFIX-to-tool-paths.patch
@@ -5,7 +5,7 @@
  
  set(PKGDATA
 -    ${TOOLBINDIR}/pkgdata
-+    ${TOOLBINDIR}/pkgdata${CMAKE_EXECUTABLE_SUFFIX}
++    ${CMAKE_CROSSCOMPILING_EMULATOR} ${TOOLBINDIR}/pkgdata${CMAKE_EXECUTABLE_SUFFIX}
      ${PKGDATA_OPTS}
      -c # --copyright
      -s
@@ -14,7 +14,7 @@
          add_custom_command(
              OUTPUT ${ICUDATA_SOURCE_ARCHIVE} ${icudata_source_archive_STAMP}
 -            COMMAND ${TOOLBINDIR}/icupkg -t${ICUDATA_CHAR} # --type
-+            COMMAND ${TOOLBINDIR}/icupkg${CMAKE_EXECUTABLE_SUFFIX} -t${ICUDATA_CHAR} # --type
++            COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${TOOLBINDIR}/icupkg${CMAKE_EXECUTABLE_SUFFIX} -t${ICUDATA_CHAR} # --type
                      ${ICUDATA_ARCHIVE} ${ICUDATA_SOURCE_ARCHIVE}
              COMMAND ${CMAKE_COMMAND} -E touch ${icudata_source_archive_STAMP}
              DEPENDS ${deps_icupkg} ${ICUDATA_ARCHIVE} # ${OUTDIR}
@@ -23,7 +23,7 @@
              COMMAND ${CMAKE_COMMAND} -E remove -f ${PKGDATA_LIST}
              COMMAND
 -                ${TOOLBINDIR}/icupkg -d ${BUILDDIR} # --destdir
-+                ${TOOLBINDIR}/icupkg${CMAKE_EXECUTABLE_SUFFIX} -d ${BUILDDIR} # --destdir
++                ${CMAKE_CROSSCOMPILING_EMULATOR} ${TOOLBINDIR}/icupkg${CMAKE_EXECUTABLE_SUFFIX} -d ${BUILDDIR} # --destdir
                  --list -x ${extract_pattern} # --extract
                  ${ICUDATA_SOURCE_ARCHIVE} -o ${PKGDATA_LIST} # --outlist
              COMMAND ${CMAKE_COMMAND} -E touch ${pkgdata_list_STAMP}
@@ -36,7 +36,7 @@
 -    DEPENDS data_dirs ${IN_DIR}/mappings/convrtrs.txt ${TOOLBINDIR}/gencnval
 -    COMMAND ${TOOLBINDIR}/gencnval -s ${IN_DIR} -d ${OUT_DIR} mappings/convrtrs.txt
 +    DEPENDS data_dirs ${IN_DIR}/mappings/convrtrs.txt ${TOOLBINDIR}/gencnval${CMAKE_EXECUTABLE_SUFFIX}
-+    COMMAND ${TOOLBINDIR}/gencnval${CMAKE_EXECUTABLE_SUFFIX} -s ${IN_DIR} -d ${OUT_DIR} mappings/convrtrs.txt
++    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${TOOLBINDIR}/gencnval${CMAKE_EXECUTABLE_SUFFIX} -s ${IN_DIR} -d ${OUT_DIR} mappings/convrtrs.txt
  )
  
  add_custom_command(
@@ -44,7 +44,7 @@
 -    DEPENDS data_dirs ${IN_DIR}/in/ulayout.icu ${TOOLBINDIR}/icupkg
 -    COMMAND ${TOOLBINDIR}/icupkg -t${ICUDATA_CHAR} ${IN_DIR}/in/ulayout.icu ${OUT_DIR}/ulayout.icu
 +    DEPENDS data_dirs ${IN_DIR}/in/ulayout.icu ${TOOLBINDIR}/icupkg${CMAKE_EXECUTABLE_SUFFIX}
-+    COMMAND ${TOOLBINDIR}/icupkg${CMAKE_EXECUTABLE_SUFFIX} -t${ICUDATA_CHAR} ${IN_DIR}/in/ulayout.icu ${OUT_DIR}/ulayout.icu
++    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${TOOLBINDIR}/icupkg${CMAKE_EXECUTABLE_SUFFIX} -t${ICUDATA_CHAR} ${IN_DIR}/in/ulayout.icu ${OUT_DIR}/ulayout.icu
  )
  
  add_custom_command(
@@ -53,7 +53,7 @@
 -            ${IN_DIR}/unidata/confusablesWholeScript.txt ${TOOLBINDIR}/gencfu
 -    COMMAND ${TOOLBINDIR}/gencfu -d ${OUT_DIR} -i ${OUT_DIR} -c -r ${IN_DIR}/unidata/confusables.txt -w
 +            ${IN_DIR}/unidata/confusablesWholeScript.txt ${TOOLBINDIR}/gencfu${CMAKE_EXECUTABLE_SUFFIX}
-+    COMMAND ${TOOLBINDIR}/gencfu${CMAKE_EXECUTABLE_SUFFIX} -d ${OUT_DIR} -i ${OUT_DIR} -c -r ${IN_DIR}/unidata/confusables.txt -w
++    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${TOOLBINDIR}/gencfu${CMAKE_EXECUTABLE_SUFFIX} -d ${OUT_DIR} -i ${OUT_DIR} -c -r ${IN_DIR}/unidata/confusables.txt -w
              ${IN_DIR}/unidata/confusablesWholeScript.txt -o confusables.cfu
  )
  
@@ -64,7 +64,7 @@
 -        DEPENDS data_dirs ${IN_DIR}/mappings/${FILE}.ucm ${TOOLBINDIR}/makeconv
 -        COMMAND ${TOOLBINDIR}/makeconv -s ${IN_DIR} -d ${OUT_DIR} -c ${CNV_INPUT}
 +        DEPENDS data_dirs ${IN_DIR}/mappings/${FILE}.ucm ${TOOLBINDIR}/makeconv${CMAKE_EXECUTABLE_SUFFIX}
-+        COMMAND ${TOOLBINDIR}/makeconv${CMAKE_EXECUTABLE_SUFFIX} -s ${IN_DIR} -d ${OUT_DIR} -c ${CNV_INPUT}
++        COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${TOOLBINDIR}/makeconv${CMAKE_EXECUTABLE_SUFFIX} -s ${IN_DIR} -d ${OUT_DIR} -c ${CNV_INPUT}
      )
  endfunction()
  
@@ -75,7 +75,7 @@
 -        DEPENDS data_dirs ${BRKITR_BRK_DEPS} ${IN_DIR}/brkitr/rules/${FILE}.txt ${TOOLBINDIR}/genbrk
 -        COMMAND ${TOOLBINDIR}/genbrk -d ${OUT_DIR} -i ${OUT_DIR} -c -r
 +        DEPENDS data_dirs ${BRKITR_BRK_DEPS} ${IN_DIR}/brkitr/rules/${FILE}.txt ${TOOLBINDIR}/genbrk${CMAKE_EXECUTABLE_SUFFIX}
-+        COMMAND ${TOOLBINDIR}/genbrk${CMAKE_EXECUTABLE_SUFFIX} -d ${OUT_DIR} -i ${OUT_DIR} -c -r
++        COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${TOOLBINDIR}/genbrk${CMAKE_EXECUTABLE_SUFFIX} -d ${OUT_DIR} -i ${OUT_DIR} -c -r
                  ${IN_DIR}/brkitr/rules/${FILE}.txt -o brkitr/${FILE}.brk
      )
  endmacro()
@@ -86,7 +86,7 @@
 -        DEPENDS data_dirs ${STRINGPREP_DEPS} ${IN_DIR}/sprep/${FILE}.txt ${TOOLBINDIR}/gensprep
 -        COMMAND ${TOOLBINDIR}/gensprep -s ${IN_DIR}/sprep -d ${OUT_DIR} -i ${OUT_DIR} -b ${SPP_FILE} -m
 +        DEPENDS data_dirs ${STRINGPREP_DEPS} ${IN_DIR}/sprep/${FILE}.txt ${TOOLBINDIR}/gensprep${CMAKE_EXECUTABLE_SUFFIX}
-+        COMMAND ${TOOLBINDIR}/gensprep${CMAKE_EXECUTABLE_SUFFIX} -s ${IN_DIR}/sprep -d ${OUT_DIR} -i ${OUT_DIR} -b ${SPP_FILE} -m
++        COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${TOOLBINDIR}/gensprep${CMAKE_EXECUTABLE_SUFFIX} -s ${IN_DIR}/sprep -d ${OUT_DIR} -i ${OUT_DIR} -b ${SPP_FILE} -m
                  ${IN_DIR}/unidata -u 3.2.0 ${FILE}.txt
      )
  endmacro()
@@ -97,7 +97,7 @@
 -        DEPENDS data_dirs ${IN_DIR}/brkitr/dictionaries/${FILE}.txt ${TOOLBINDIR}/gendict
 -        COMMAND ${TOOLBINDIR}/gendict -i ${OUT_DIR} -c ${BRKITR_DICT_${FILE}_FLAGS}
 +        DEPENDS data_dirs ${IN_DIR}/brkitr/dictionaries/${FILE}.txt ${TOOLBINDIR}/gendict${CMAKE_EXECUTABLE_SUFFIX}
-+        COMMAND ${TOOLBINDIR}/gendict${CMAKE_EXECUTABLE_SUFFIX} -i ${OUT_DIR} -c ${BRKITR_DICT_${FILE}_FLAGS}
++        COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${TOOLBINDIR}/gendict${CMAKE_EXECUTABLE_SUFFIX} -i ${OUT_DIR} -c ${BRKITR_DICT_${FILE}_FLAGS}
                  ${IN_DIR}/brkitr/dictionaries/${FILE}.txt ${OUT_DIR}/brkitr/${FILE}.dict
      )
  endfunction()
@@ -108,7 +108,7 @@
 -        DEPENDS data_dirs ${IN_DIR}/in/${FILE}.nrm ${TOOLBINDIR}/icupkg
 -        COMMAND ${TOOLBINDIR}/icupkg -t${ICUDATA_CHAR} ${IN_DIR}/in/${FILE}.nrm ${OUT_DIR}/${FILE}.nrm
 +        DEPENDS data_dirs ${IN_DIR}/in/${FILE}.nrm ${TOOLBINDIR}/icupkg${CMAKE_EXECUTABLE_SUFFIX}
-+        COMMAND ${TOOLBINDIR}/icupkg${CMAKE_EXECUTABLE_SUFFIX} -t${ICUDATA_CHAR} ${IN_DIR}/in/${FILE}.nrm ${OUT_DIR}/${FILE}.nrm
++        COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${TOOLBINDIR}/icupkg${CMAKE_EXECUTABLE_SUFFIX} -t${ICUDATA_CHAR} ${IN_DIR}/in/${FILE}.nrm ${OUT_DIR}/${FILE}.nrm
      )
  endfunction()
  
@@ -119,7 +119,7 @@
 -    DEPENDS data_dirs ${IN_DIR}/in/coll/ucadata-unihan.icu ${TOOLBINDIR}/icupkg
 -    COMMAND ${TOOLBINDIR}/icupkg -t${ICUDATA_CHAR} ${IN_DIR}/in/coll/ucadata-unihan.icu
 +    DEPENDS data_dirs ${IN_DIR}/in/coll/ucadata-unihan.icu ${TOOLBINDIR}/icupkg${CMAKE_EXECUTABLE_SUFFIX}
-+    COMMAND ${TOOLBINDIR}/icupkg${CMAKE_EXECUTABLE_SUFFIX} -t${ICUDATA_CHAR} ${IN_DIR}/in/coll/ucadata-unihan.icu
++    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${TOOLBINDIR}/icupkg${CMAKE_EXECUTABLE_SUFFIX} -t${ICUDATA_CHAR} ${IN_DIR}/in/coll/ucadata-unihan.icu
              ${OUT_DIR}/coll/ucadata.icu
  )
  
@@ -130,7 +130,7 @@
 -    DEPENDS data_dirs ${IN_DIR}/in/unames.icu ${TOOLBINDIR}/icupkg
 -    COMMAND ${TOOLBINDIR}/icupkg -t${ICUDATA_CHAR} ${IN_DIR}/in/unames.icu ${OUT_DIR}/unames.icu
 +    DEPENDS data_dirs ${IN_DIR}/in/unames.icu ${TOOLBINDIR}/icupkg${CMAKE_EXECUTABLE_SUFFIX}
-+    COMMAND ${TOOLBINDIR}/icupkg${CMAKE_EXECUTABLE_SUFFIX} -t${ICUDATA_CHAR} ${IN_DIR}/in/unames.icu ${OUT_DIR}/unames.icu
++    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${TOOLBINDIR}/icupkg${CMAKE_EXECUTABLE_SUFFIX} -t${ICUDATA_CHAR} ${IN_DIR}/in/unames.icu ${OUT_DIR}/unames.icu
  )
  
  # misc res
@@ -141,7 +141,7 @@
 -        DEPENDS data_dirs ${IN_DIR}/misc/${FILE}.txt ${TOOLBINDIR}/genrb
 -        COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/misc -d ${OUT_DIR} -i ${OUT_DIR} -k -q ${FILE}.txt
 +        DEPENDS data_dirs ${IN_DIR}/misc/${FILE}.txt ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX}
-+        COMMAND ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${IN_DIR}/misc -d ${OUT_DIR} -i ${OUT_DIR} -k -q ${FILE}.txt
++        COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${IN_DIR}/misc -d ${OUT_DIR} -i ${OUT_DIR} -k -q ${FILE}.txt
      )
  endfunction()
  
@@ -152,7 +152,7 @@
 -    DEPENDS data_dirs ${IN_DIR}/curr/supplementalData.txt ${TOOLBINDIR}/genrb
 -    COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/curr -d ${OUT_DIR}/curr -i ${OUT_DIR} -k -q
 +    DEPENDS data_dirs ${IN_DIR}/curr/supplementalData.txt ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX}
-+    COMMAND ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${IN_DIR}/curr -d ${OUT_DIR}/curr -i ${OUT_DIR} -k -q
++    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${IN_DIR}/curr -d ${OUT_DIR}/curr -i ${OUT_DIR} -k -q
              supplementalData.txt
  )
  list(APPEND tmpdep ${OUT_DIR}/curr/supplementalData.res)
@@ -163,7 +163,7 @@
 -    DEPENDS data_dirs ${IN_DIR}/translit/root.txt ${TRANSLIT_RES_DEPS} ${TOOLBINDIR}/genrb
 -    COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/translit -d ${OUT_DIR}/translit/ -i ${OUT_DIR} -k root.txt
 +    DEPENDS data_dirs ${IN_DIR}/translit/root.txt ${TRANSLIT_RES_DEPS} ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX}
-+    COMMAND ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${IN_DIR}/translit -d ${OUT_DIR}/translit/ -i ${OUT_DIR} -k root.txt
++    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${IN_DIR}/translit -d ${OUT_DIR}/translit/ -i ${OUT_DIR} -k root.txt
  )
  
  add_custom_command(
@@ -171,7 +171,7 @@
 -    DEPENDS data_dirs ${IN_DIR}/translit/en.txt ${TRANSLIT_RES_DEPS} ${TOOLBINDIR}/genrb
 -    COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/translit -d ${OUT_DIR}/translit/ -i ${OUT_DIR} -k en.txt
 +    DEPENDS data_dirs ${IN_DIR}/translit/en.txt ${TRANSLIT_RES_DEPS} ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX}
-+    COMMAND ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${IN_DIR}/translit -d ${OUT_DIR}/translit/ -i ${OUT_DIR} -k en.txt
++    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${IN_DIR}/translit -d ${OUT_DIR}/translit/ -i ${OUT_DIR} -k en.txt
  )
  
  add_custom_command(
@@ -179,7 +179,7 @@
 -    DEPENDS data_dirs ${IN_DIR}/translit/el.txt ${TRANSLIT_RES_DEPS} ${TOOLBINDIR}/genrb
 -    COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/translit -d ${OUT_DIR}/translit/ -i ${OUT_DIR} -k el.txt
 +    DEPENDS data_dirs ${IN_DIR}/translit/el.txt ${TRANSLIT_RES_DEPS} ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX}
-+    COMMAND ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${IN_DIR}/translit -d ${OUT_DIR}/translit/ -i ${OUT_DIR} -k el.txt
++    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${IN_DIR}/translit -d ${OUT_DIR}/translit/ -i ${OUT_DIR} -k el.txt
  )
  
  # locales pool
@@ -190,7 +190,7 @@
 -    DEPENDS data_dirs ${LOCALES_POOL_WRITE_DEPS} ${TOOLBINDIR}/genrb
 -    COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/locales -d ${OUT_DIR}/ -i ${OUT_DIR} --writePoolBundle -k
 +    DEPENDS data_dirs ${LOCALES_POOL_WRITE_DEPS} ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX}
-+    COMMAND ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${IN_DIR}/locales -d ${OUT_DIR}/ -i ${OUT_DIR} --writePoolBundle -k
++    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${IN_DIR}/locales -d ${OUT_DIR}/ -i ${OUT_DIR} --writePoolBundle -k
              ${LOCALES_POOL_WRITE_FILES}
  )
  
@@ -201,7 +201,7 @@
 -        DEPENDS data_dirs ${IN_DIR}/locales/${ITEM}.txt ${LOCALES_RES_DEPS} ${TOOLBINDIR}/genrb
 -        COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/locales -d ${OUT_DIR}/ -i ${OUT_DIR} --usePoolBundle
 +        DEPENDS data_dirs ${IN_DIR}/locales/${ITEM}.txt ${LOCALES_RES_DEPS} ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX}
-+        COMMAND ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${IN_DIR}/locales -d ${OUT_DIR}/ -i ${OUT_DIR} --usePoolBundle
++        COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${IN_DIR}/locales -d ${OUT_DIR}/ -i ${OUT_DIR} --usePoolBundle
                  ${OUT_DIR}/ -k ${ITEM}.txt
      )
  endfunction()
@@ -212,7 +212,7 @@
 -    DEPENDS data_dirs ${TMP_DIR}/locales/${INDEX_NAME}.txt ${TOOLBINDIR}/genrb
 -    COMMAND ${TOOLBINDIR}/genrb -s ${TMP_DIR}/locales -d ${OUT_DIR}/ -i ${OUT_DIR} -k ${INDEX_NAME}.txt
 +    DEPENDS data_dirs ${TMP_DIR}/locales/${INDEX_NAME}.txt ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX}
-+    COMMAND ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${TMP_DIR}/locales -d ${OUT_DIR}/ -i ${OUT_DIR} -k ${INDEX_NAME}.txt
++    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${TMP_DIR}/locales -d ${OUT_DIR}/ -i ${OUT_DIR} -k ${INDEX_NAME}.txt
  )
  
  # curr pool
@@ -223,7 +223,7 @@
 -    DEPENDS data_dirs ${CURR_POOL_WRITE_DEPS} ${TOOLBINDIR}/genrb
 -    COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/curr -d ${OUT_DIR}/curr/ -i ${OUT_DIR} --writePoolBundle -k
 +    DEPENDS data_dirs ${CURR_POOL_WRITE_DEPS} ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX}
-+    COMMAND ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${IN_DIR}/curr -d ${OUT_DIR}/curr/ -i ${OUT_DIR} --writePoolBundle -k
++    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${IN_DIR}/curr -d ${OUT_DIR}/curr/ -i ${OUT_DIR} --writePoolBundle -k
              ${CURR_POOL_WRITE_FILES}
  )
  
@@ -234,7 +234,7 @@
 -        DEPENDS data_dirs ${IN_DIR}/curr/${ITEM}.txt ${CURR_RES_DEPS} ${TOOLBINDIR}/genrb
 -        COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/curr -d ${OUT_DIR}/curr/ -i ${OUT_DIR} --usePoolBundle
 +        DEPENDS data_dirs ${IN_DIR}/curr/${ITEM}.txt ${CURR_RES_DEPS} ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX}
-+        COMMAND ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${IN_DIR}/curr -d ${OUT_DIR}/curr/ -i ${OUT_DIR} --usePoolBundle
++        COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${IN_DIR}/curr -d ${OUT_DIR}/curr/ -i ${OUT_DIR} --usePoolBundle
                  ${OUT_DIR}/curr/ -k ${ITEM}.txt
      )
  endfunction()
@@ -245,7 +245,7 @@
 -    DEPENDS data_dirs ${TMP_DIR}/curr/${INDEX_NAME}.txt ${TOOLBINDIR}/genrb
 -    COMMAND ${TOOLBINDIR}/genrb -s ${TMP_DIR}/curr -d ${OUT_DIR}/curr/ -i ${OUT_DIR} -k
 +    DEPENDS data_dirs ${TMP_DIR}/curr/${INDEX_NAME}.txt ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX}
-+    COMMAND ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${TMP_DIR}/curr -d ${OUT_DIR}/curr/ -i ${OUT_DIR} -k
++    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${TMP_DIR}/curr -d ${OUT_DIR}/curr/ -i ${OUT_DIR} -k
              ${INDEX_NAME}.txt
  )
  list(APPEND tmpdep ${OUT_DIR}/curr/${INDEX_NAME}.res)
@@ -256,7 +256,7 @@
 -    DEPENDS data_dirs ${LANG_POOL_WRITE_DEPS} ${TOOLBINDIR}/genrb
 -    COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/lang -d ${OUT_DIR}/lang/ -i ${OUT_DIR} --writePoolBundle -k
 +    DEPENDS data_dirs ${LANG_POOL_WRITE_DEPS} ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX}
-+    COMMAND ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${IN_DIR}/lang -d ${OUT_DIR}/lang/ -i ${OUT_DIR} --writePoolBundle -k
++    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${IN_DIR}/lang -d ${OUT_DIR}/lang/ -i ${OUT_DIR} --writePoolBundle -k
              ${LANG_POOL_WRITE_FILES}
  )
  
@@ -267,7 +267,7 @@
 -        DEPENDS data_dirs ${IN_DIR}/lang/${ITEM}.txt ${LANG_RES_DEPS} ${TOOLBINDIR}/genrb
 -        COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/lang -d ${OUT_DIR}/lang/ -i ${OUT_DIR} --usePoolBundle
 +        DEPENDS data_dirs ${IN_DIR}/lang/${ITEM}.txt ${LANG_RES_DEPS} ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX}
-+        COMMAND ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${IN_DIR}/lang -d ${OUT_DIR}/lang/ -i ${OUT_DIR} --usePoolBundle
++        COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${IN_DIR}/lang -d ${OUT_DIR}/lang/ -i ${OUT_DIR} --usePoolBundle
                  ${OUT_DIR}/lang/ -k ${ITEM}.txt
      )
  endfunction()
@@ -278,7 +278,7 @@
 -    DEPENDS data_dirs ${TMP_DIR}/lang/${INDEX_NAME}.txt ${TOOLBINDIR}/genrb
 -    COMMAND ${TOOLBINDIR}/genrb -s ${TMP_DIR}/lang -d ${OUT_DIR}/lang/ -i ${OUT_DIR} -k
 +    DEPENDS data_dirs ${TMP_DIR}/lang/${INDEX_NAME}.txt ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX}
-+    COMMAND ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${TMP_DIR}/lang -d ${OUT_DIR}/lang/ -i ${OUT_DIR} -k
++    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${TMP_DIR}/lang -d ${OUT_DIR}/lang/ -i ${OUT_DIR} -k
              ${INDEX_NAME}.txt
  )
  
@@ -289,7 +289,7 @@
 -    DEPENDS data_dirs ${REGION_POOL_WRITE_DEPS} ${TOOLBINDIR}/genrb
 -    COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/region -d ${OUT_DIR}/region/ -i ${OUT_DIR}
 +    DEPENDS data_dirs ${REGION_POOL_WRITE_DEPS} ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX}
-+    COMMAND ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${IN_DIR}/region -d ${OUT_DIR}/region/ -i ${OUT_DIR}
++    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${IN_DIR}/region -d ${OUT_DIR}/region/ -i ${OUT_DIR}
              --writePoolBundle -k ${REGION_POOL_WRITE_FILES}
  )
  
@@ -300,7 +300,7 @@
 -        DEPENDS data_dirs ${IN_DIR}/region/${ITEM}.txt ${REGION_RES_DEPS} ${TOOLBINDIR}/genrb
 -        COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/region -d ${OUT_DIR}/region/ -i ${OUT_DIR}
 +        DEPENDS data_dirs ${IN_DIR}/region/${ITEM}.txt ${REGION_RES_DEPS} ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX}
-+        COMMAND ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${IN_DIR}/region -d ${OUT_DIR}/region/ -i ${OUT_DIR}
++        COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${IN_DIR}/region -d ${OUT_DIR}/region/ -i ${OUT_DIR}
                  --usePoolBundle ${OUT_DIR}/region/ -k ${ITEM}.txt
      )
  endfunction()
@@ -311,7 +311,7 @@
 -    DEPENDS data_dirs ${TMP_DIR}/region/${INDEX_NAME}.txt ${TOOLBINDIR}/genrb
 -    COMMAND ${TOOLBINDIR}/genrb -s ${TMP_DIR}/region -d ${OUT_DIR}/region/ -i ${OUT_DIR} -k
 +    DEPENDS data_dirs ${TMP_DIR}/region/${INDEX_NAME}.txt ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX}
-+    COMMAND ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${TMP_DIR}/region -d ${OUT_DIR}/region/ -i ${OUT_DIR} -k
++    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${TMP_DIR}/region -d ${OUT_DIR}/region/ -i ${OUT_DIR} -k
              ${INDEX_NAME}.txt
  )
  
@@ -322,7 +322,7 @@
 -    DEPENDS data_dirs ${ZONE_POOL_WRITE_DEPS} ${TOOLBINDIR}/genrb
 -    COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/zone -d ${OUT_DIR}/zone/ -i ${OUT_DIR} --writePoolBundle -k
 +    DEPENDS data_dirs ${ZONE_POOL_WRITE_DEPS} ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX}
-+    COMMAND ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${IN_DIR}/zone -d ${OUT_DIR}/zone/ -i ${OUT_DIR} --writePoolBundle -k
++    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${IN_DIR}/zone -d ${OUT_DIR}/zone/ -i ${OUT_DIR} --writePoolBundle -k
              ${ZONE_POOL_WRITE_FILES}
  )
  
@@ -333,7 +333,7 @@
 -        DEPENDS data_dirs ${IN_DIR}/zone/${ITEM}.txt ${ZONE_RES_DEPS} ${TOOLBINDIR}/genrb
 -        COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/zone -d ${OUT_DIR}/zone/ -i ${OUT_DIR} --usePoolBundle
 +        DEPENDS data_dirs ${IN_DIR}/zone/${ITEM}.txt ${ZONE_RES_DEPS} ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX}
-+        COMMAND ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${IN_DIR}/zone -d ${OUT_DIR}/zone/ -i ${OUT_DIR} --usePoolBundle
++        COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${IN_DIR}/zone -d ${OUT_DIR}/zone/ -i ${OUT_DIR} --usePoolBundle
                  ${OUT_DIR}/zone/ -k ${ITEM}.txt
      )
  endfunction()
@@ -344,7 +344,7 @@
 -    DEPENDS data_dirs ${TMP_DIR}/zone/${INDEX_NAME}.txt ${TOOLBINDIR}/genrb
 -    COMMAND ${TOOLBINDIR}/genrb -s ${TMP_DIR}/zone -d ${OUT_DIR}/zone/ -i ${OUT_DIR} -k
 +    DEPENDS data_dirs ${TMP_DIR}/zone/${INDEX_NAME}.txt ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX}
-+    COMMAND ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${TMP_DIR}/zone -d ${OUT_DIR}/zone/ -i ${OUT_DIR} -k
++    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${TMP_DIR}/zone -d ${OUT_DIR}/zone/ -i ${OUT_DIR} -k
              ${INDEX_NAME}.txt
  )
  
@@ -355,7 +355,7 @@
 -    DEPENDS data_dirs ${UNIT_POOL_WRITE_DEPS} ${TOOLBINDIR}/genrb
 -    COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/unit -d ${OUT_DIR}/unit/ -i ${OUT_DIR} --writePoolBundle -k
 +    DEPENDS data_dirs ${UNIT_POOL_WRITE_DEPS} ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX}
-+    COMMAND ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${IN_DIR}/unit -d ${OUT_DIR}/unit/ -i ${OUT_DIR} --writePoolBundle -k
++    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${IN_DIR}/unit -d ${OUT_DIR}/unit/ -i ${OUT_DIR} --writePoolBundle -k
              ${UNIT_POOL_WRITE_FILES}
  )
  
@@ -366,7 +366,7 @@
 -        DEPENDS data_dirs ${IN_DIR}/unit/${ITEM}.txt ${UNIT_RES_DEPS} ${TOOLBINDIR}/genrb
 -        COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/unit -d ${OUT_DIR}/unit/ -i ${OUT_DIR} --usePoolBundle
 +        DEPENDS data_dirs ${IN_DIR}/unit/${ITEM}.txt ${UNIT_RES_DEPS} ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX}
-+        COMMAND ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${IN_DIR}/unit -d ${OUT_DIR}/unit/ -i ${OUT_DIR} --usePoolBundle
++        COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${IN_DIR}/unit -d ${OUT_DIR}/unit/ -i ${OUT_DIR} --usePoolBundle
                  ${OUT_DIR}/unit/ -k ${ITEM}.txt
      )
  endfunction()
@@ -377,7 +377,7 @@
 -    DEPENDS data_dirs ${TMP_DIR}/unit/${INDEX_NAME}.txt ${TOOLBINDIR}/genrb
 -    COMMAND ${TOOLBINDIR}/genrb -s ${TMP_DIR}/unit -d ${OUT_DIR}/unit/ -i ${OUT_DIR} -k
 +    DEPENDS data_dirs ${TMP_DIR}/unit/${INDEX_NAME}.txt ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX}
-+    COMMAND ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${TMP_DIR}/unit -d ${OUT_DIR}/unit/ -i ${OUT_DIR} -k
++    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${TMP_DIR}/unit -d ${OUT_DIR}/unit/ -i ${OUT_DIR} -k
              ${INDEX_NAME}.txt
  )
  
@@ -388,7 +388,7 @@
 -        DEPENDS data_dirs ${IN_DIR}/coll/${ITEM}.txt ${COLL_RES_DEPS} ${TOOLBINDIR}/genrb
 -        COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/coll -d ${OUT_DIR}/coll/ -i ${OUT_DIR} -k ${ITEM}.txt
 +        DEPENDS data_dirs ${IN_DIR}/coll/${ITEM}.txt ${COLL_RES_DEPS} ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX}
-+        COMMAND ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${IN_DIR}/coll -d ${OUT_DIR}/coll/ -i ${OUT_DIR} -k ${ITEM}.txt
++        COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${IN_DIR}/coll -d ${OUT_DIR}/coll/ -i ${OUT_DIR} -k ${ITEM}.txt
      )
  endfunction()
  
@@ -399,7 +399,7 @@
 -    DEPENDS data_dirs ${TMP_DIR}/coll/${INDEX_NAME}.txt ${TOOLBINDIR}/genrb
 -    COMMAND ${TOOLBINDIR}/genrb -s ${TMP_DIR}/coll -d ${OUT_DIR}/coll/ -i ${OUT_DIR} -k
 +    DEPENDS data_dirs ${TMP_DIR}/coll/${INDEX_NAME}.txt ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX}
-+    COMMAND ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${TMP_DIR}/coll -d ${OUT_DIR}/coll/ -i ${OUT_DIR} -k
++    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${TMP_DIR}/coll -d ${OUT_DIR}/coll/ -i ${OUT_DIR} -k
              ${INDEX_NAME}.txt
  )
  
@@ -410,7 +410,7 @@
 -        DEPENDS data_dirs ${IN_DIR}/brkitr/${ITEM}.txt ${BRKITR_RES_DEPS} ${TOOLBINDIR}/genrb
 -        COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/brkitr -d ${OUT_DIR}/brkitr/ -i ${OUT_DIR} -k
 +        DEPENDS data_dirs ${IN_DIR}/brkitr/${ITEM}.txt ${BRKITR_RES_DEPS} ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX}
-+        COMMAND ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${IN_DIR}/brkitr -d ${OUT_DIR}/brkitr/ -i ${OUT_DIR} -k
++        COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${IN_DIR}/brkitr -d ${OUT_DIR}/brkitr/ -i ${OUT_DIR} -k
                  ${ITEM}.txt
      )
  endfunction()
@@ -421,7 +421,7 @@
 -    DEPENDS data_dirs ${TMP_DIR}/brkitr/${INDEX_NAME}.txt ${TOOLBINDIR}/genrb
 -    COMMAND ${TOOLBINDIR}/genrb -s ${TMP_DIR}/brkitr -d ${OUT_DIR}/brkitr/ -i ${OUT_DIR} -k
 +    DEPENDS data_dirs ${TMP_DIR}/brkitr/${INDEX_NAME}.txt ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX}
-+    COMMAND ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${TMP_DIR}/brkitr -d ${OUT_DIR}/brkitr/ -i ${OUT_DIR} -k
++    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${TMP_DIR}/brkitr -d ${OUT_DIR}/brkitr/ -i ${OUT_DIR} -k
              ${INDEX_NAME}.txt
  )
  
@@ -432,7 +432,7 @@
 -        DEPENDS data_dirs ${IN_DIR}/rbnf/${ITEM}.txt ${RBNF_DEPS} ${TOOLBINDIR}/genrb
 -        COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/rbnf -d ${OUT_DIR}/rbnf/ -i ${OUT_DIR} -k ${ITEM}.txt
 +        DEPENDS data_dirs ${IN_DIR}/rbnf/${ITEM}.txt ${RBNF_DEPS} ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX}
-+        COMMAND ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${IN_DIR}/rbnf -d ${OUT_DIR}/rbnf/ -i ${OUT_DIR} -k ${ITEM}.txt
++        COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${IN_DIR}/rbnf -d ${OUT_DIR}/rbnf/ -i ${OUT_DIR} -k ${ITEM}.txt
      )
  endfunction()
  
@@ -443,7 +443,7 @@
 -    DEPENDS data_dirs ${TMP_DIR}/rbnf/${INDEX_NAME}.txt ${TOOLBINDIR}/genrb
 -    COMMAND ${TOOLBINDIR}/genrb -s ${TMP_DIR}/rbnf -d ${OUT_DIR}/rbnf/ -i ${OUT_DIR} -k
 +    DEPENDS data_dirs ${TMP_DIR}/rbnf/${INDEX_NAME}.txt ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX}
-+    COMMAND ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${TMP_DIR}/rbnf -d ${OUT_DIR}/rbnf/ -i ${OUT_DIR} -k
++    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${TOOLBINDIR}/genrb${CMAKE_EXECUTABLE_SUFFIX} -s ${TMP_DIR}/rbnf -d ${OUT_DIR}/rbnf/ -i ${OUT_DIR} -k
              ${INDEX_NAME}.txt
  )
  

--- a/ports/icu/portfile.cmake
+++ b/ports/icu/portfile.cmake
@@ -20,7 +20,7 @@ set(PATCHES
     ${CMAKE_CURRENT_LIST_DIR}/patches/0001-Add-CMake-platform.patch
     # Patch specifically for vcpkg on top of above
     ${CMAKE_CURRENT_LIST_DIR}/patches/0002-Remove-install-suffix-on-Windows.patch
-    # Append CMAKE_EXECUTABLE_SUFFIX to tool paths for cross-compilation
+    # Append CMAKE_EXECUTABLE_SUFFIX and CMAKE_CROSSCOMPILING_EMULATOR to tool paths for cross-compilation
     ${CMAKE_CURRENT_LIST_DIR}/patches/0003-Append-CMAKE_EXECUTABLE_SUFFIX-to-tool-paths.patch
     # Copy stubdata DLL to bin/ during cross-compilation (not just native Windows)
     ${CMAKE_CURRENT_LIST_DIR}/patches/0004-Copy-stubdata-dll-to-bin-for-cross-compile.patch

--- a/ports/icu/vcpkg.json
+++ b/ports/icu/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "icu",
   "version": "77.1.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "ICU is a mature, widely used set of C/C++ and Java libraries providing Unicode and Globalization support for software applications. ICU is widely portable and gives applications the same results on all platforms and between C/C++ and Java software.",
   "homepage": "http://site.icu-project.org",
   "license": "ICU",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10,7 +10,7 @@
     },
     "icu": {
       "baseline": "77.1.0",
-      "port-version": 1
+      "port-version": 2
     },
     "openssl": {
       "baseline": "libressl",

--- a/versions/i-/icu.json
+++ b/versions/i-/icu.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7bafd08eb7d79f91435e30201e0a50b12bf0f996",
+      "version": "77.1.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "34ccf9737b64c2d689e9df0d324f4cb9da0f6054",
       "version": "77.1.0",
       "port-version": 1


### PR DESCRIPTION
This allows us to get rid of the binfmt_misc requirement from the cross-compile, making it way easier to run inside a container.